### PR TITLE
Fix buffer overrun in showString()

### DIFF
--- a/arduino/splitflap/esp32/core/splitflap_task.cpp
+++ b/arduino/splitflap/esp32/core/splitflap_task.cpp
@@ -320,7 +320,7 @@ void SplitflapTask::log(const char* msg) {
 void SplitflapTask::showString(const char* str, uint8_t length, bool force_full_rotation) {
     Command command = {};
     command.command_type = CommandType::MODULES;
-    for (uint8_t i = 0; i < length; i++) {
+    for (uint8_t i = 0; i < length && i < NUM_MODULES; i++) {
         int8_t index = findFlapIndex(str[i]);
         if (index != -1) {
             if (force_full_rotation || index != modules[i]->GetTargetFlapIndex()) {


### PR DESCRIPTION
Add a check to showString() to prevent buffer overrun.